### PR TITLE
Fix workflow patterns

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
   check_changes:
     uses: patmoreau/workflow-config/.github/workflows/check-changes-action.yml@main
     with:
-      file_patterns: ${{ vars.CODE_FILE_PATTERNS }}
+      file_patterns: ${{ vars.CICD_CODE_FILE_PATTERNS }}
 
   set-version:
     name: Set version

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
   check_changes:
     uses: patmoreau/workflow-config/.github/workflows/check-changes-action.yml@main
     with:
-      file_patterns: ${{ vars.CODE_FILE_PATTERNS }}
+      file_patterns: ${{ vars.CODEQL_CODE_FILE_PATTERNS }}
 
   analyze:
     name: Analyze

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,7 +24,7 @@ jobs:
   check_changes:
     uses: patmoreau/workflow-config/.github/workflows/check-changes-action.yml@main
     with:
-      file_patterns: ${{ vars.CODE_FILE_PATTERNS }}
+      file_patterns: ${{ vars.LINTER_CODE_FILE_PATTERNS }}
 
   typescript:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set workflow patterns separate for each workflow, this is to force a workflow updated by renovate to actually run to make sure it succeeds.