### PR TITLE
Adds default description for transfer transactions

### DIFF
--- a/docker-compose.Staging.yaml
+++ b/docker-compose.Staging.yaml
@@ -14,6 +14,8 @@ services:
       dockerfile: ./src/Holefeeder.Api/Dockerfile
       tags:
         - '${DOCKER_REGISTRY:-holefeeder}/holefeeder-api:${VERSION:-latest}'
+    ports:
+      - 5001:80
     environment:
       FeatureManagement__temp-new-azure-b2c-config: true
 

--- a/src/Holefeeder.Application/Features/Transactions/Commands/Transfer.cs
+++ b/src/Holefeeder.Application/Features/Transactions/Commands/Transfer.cs
@@ -119,7 +119,16 @@ public class Transfer : ICarterModule
         private async Task<Result<Transaction>> CreateTransactionAsync(AccountId accountId, Category category,
             Request request, CancellationToken cancellationToken)
         {
-            var transaction = Transaction.Create(request.Date, request.Amount, request.Description,
+            var fromAccount = await context.Accounts
+                .FirstAsync(x => x.Id == request.FromAccountId && x.UserId == userContext.Id, cancellationToken);
+            var toAccount = await context.Accounts
+                .FirstAsync(x => x.Id == request.ToAccountId && x.UserId == userContext.Id, cancellationToken);
+            var description = request.Description.Trim();
+            if (string.IsNullOrEmpty(description))
+            {
+                description = $"Transfer from '{fromAccount.Name}' to '{toAccount.Name}'";
+            }
+            var transaction = Transaction.Create(request.Date, request.Amount, description,
                 accountId, category.Id, userContext.Id);
             if (transaction.IsFailure)
             {

--- a/tests/Holefeeder.FunctionalTests/Features/Transactions/ScenarioTransfer.cs
+++ b/tests/Holefeeder.FunctionalTests/Features/Transactions/ScenarioTransfer.cs
@@ -29,6 +29,16 @@ public sealed class ScenarioTransfer(ApiApplicationDriver applicationDriver, ITe
             .Then(Transaction.ShouldBeCreatedForBothAccounts)
             .PlayAsync();
 
+    [Fact]
+    public Task ValidRequestWithNoDescription() =>
+        ScenarioRunner.Create(ScenarioOutput)
+            .Given(Category.TransferCategoriesExists)
+            .And(Account.CollectionExists)
+            .And(AValidRequestWithNoDescription)
+            .When(TheUser.MakesATransfer)
+            .Then(Transaction.ShouldBeCreatedForBothAccountsWithTransferDescription)
+            .PlayAsync();
+
     private static void AnInvalidRequest(IStepRunner runner) =>
         runner.Execute(() => GivenAnInvalidTransfer().Build());
 
@@ -42,6 +52,22 @@ public sealed class ScenarioTransfer(ApiApplicationDriver applicationDriver, ITe
             var request = GivenATransfer()
                 .FromAccount(fromAccount)
                 .ToAccount(toAccount)
+                .Build();
+            runner.SetContextData(RequestContext.CurrentRequest, request);
+            return request;
+        });
+
+    private static void AValidRequestWithNoDescription(IStepRunner runner) =>
+        runner.Execute<IEnumerable<Account>, Request>(accounts =>
+        {
+            accounts.Should().BeValid()
+                .And.Subject.Value.Should().HaveCountGreaterThan(1);
+            var fromAccount = accounts.Value.First();
+            var toAccount = accounts.Value.Last();
+            var request = GivenATransfer()
+                .FromAccount(fromAccount)
+                .ToAccount(toAccount)
+                .WithNoDescription()
                 .Build();
             runner.SetContextData(RequestContext.CurrentRequest, request);
             return request;

--- a/tests/Holefeeder.Tests.Common/Builders/Transactions/TransferRequestBuilder.cs
+++ b/tests/Holefeeder.Tests.Common/Builders/Transactions/TransferRequestBuilder.cs
@@ -53,6 +53,12 @@ internal class TransferRequestBuilder : FakerBuilder<Request>
         return this;
     }
 
+    public TransferRequestBuilder WithNoDescription()
+    {
+        Faker.RuleFor(x => x.Description, string.Empty);
+        return this;
+    }
+
     public static TransferRequestBuilder GivenATransfer() => new();
 
     public static TransferRequestBuilder GivenAnInvalidTransfer()


### PR DESCRIPTION
Adds a default description for transfer transactions when the user doesn't provide one.

The default description is in the format "Transfer from '{fromAccount.Name}' to '{toAccount.Name}'".